### PR TITLE
error loading square images

### DIFF
--- a/plugins/user/profilepicture/profilepicture.php
+++ b/plugins/user/profilepicture/profilepicture.php
@@ -175,7 +175,7 @@ class plgUserProfilePicture extends JPlugin
 							$croppedHeight = $sourceHeight;
 							$resizedHeight = $resizedWidth;
 						}
-						elseif($sourceHeight > $sourceWidth)
+						elseif($sourceHeight >= $sourceWidth)
 						{
 							$left = 0;
 							$top = (int)(($sourceHeight - $sourceWidth) / 2);


### PR DESCRIPTION
if image is square JImage::crop() will not receive the parameters and it will crash