### PR TITLE
fixed error when uploading square images

### DIFF
--- a/plugins/user/profilepicture/profilepicture.php
+++ b/plugins/user/profilepicture/profilepicture.php
@@ -167,7 +167,7 @@ class plgUserProfilePicture extends JPlugin
 					
 					if($this->square && $sourceWidth > $size && $sourceHeight > $size)
 					{
-						if($sourceWidth > $sourceHeight)
+						if($sourceWidth >= $sourceHeight)
 						{
 							$left = (int)($sourceWidth - $sourceHeight) / 2;
 							$top = 0;


### PR DESCRIPTION
if uploaded image is already a square the plugins returns an error since it can't be resized
